### PR TITLE
fix: update spm patch source to permalink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
 RUN mkdir /opt/spm12 \
     && curl -SL https://github.com/spm/spm12/archive/refs/tags/r7219.tar.gz \
     | tar -xzC /opt/spm12 --strip-components 1 \
-    && curl -SL https://raw.githubusercontent.com/spm/spm-docker/main/octave/spm12_r7771.patch 
+    && curl -SL https://raw.githubusercontent.com/spm/spm-docker/687c160b9d50100079c8a7decd696d07cf66251a/octave/spm12_r7771.patch 
     
  RUN  make -C /opt/spm12/src PLATFORM=octave distclean \
     && make -C /opt/spm12/src PLATFORM=octave \


### PR DESCRIPTION
The current link for the SPM/Octave patch is broken. The `main` branch of spm/spm-docker no longer includes octave/spm12_r7771.patch ([seems like the file has been moved to a new repo](https://github.com/spm/spm-docker/commit/ace24e7620dbdd3c2a7b8e20f83f0fca097307a9)). This pull request updates the reference from volatile "main" to the last commit with the patch. 